### PR TITLE
Add configurable timeouts, fix search N+1, remove dead code; release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.0] - 2026-06-24
+
+### Added
+- `MetMuseum::Collection.new` now accepts `open_timeout:` and `read_timeout:`
+  keyword arguments (defaults: `5` / `15` seconds) to configure HTTP timeouts.
+
+### Changed
+- `search(limit:)` reuses the same client instance instead of allocating a new
+  `MetMuseum::Collection` per object id.
+- Supported Ruby versions are now 3.3, 3.4 and 3.5; `required_ruby_version` is
+  `>= 3.3`.
+
+### Removed
+- Unused private `multi_option` method.
+
+### Development
+- The spec suite is now deterministic: HTTP interactions are recorded with VCR
+  and replayed offline, so CI no longer depends on the live Met API.
+
+## [1.4.2]
+- Last release before this changelog was introduced.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    met_museum (1.4.2)
+    met_museum (1.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Or install it yourself as:
 require 'met_museum'
 ```
 
+### Configuring timeouts
+
+`MetMuseum::Collection.new` accepts optional `open_timeout` and `read_timeout`
+keyword arguments (in seconds) to control the underlying HTTP client. They
+default to `5` and `15` respectively.
+
+```rb
+collection = MetMuseum::Collection.new(open_timeout: 3, read_timeout: 10)
+collection.object(436535)
+```
+
 The description of the method is as follows
 
 <details>

--- a/lib/met_museum/collection.rb
+++ b/lib/met_museum/collection.rb
@@ -4,6 +4,13 @@ require "json"
 
 module MetMuseum
   class Collection
+    # @param [Integer] open_timeout Seconds to wait for the connection to open (default: 5).
+    # @param [Integer] read_timeout Seconds to wait for one block of the response to be read (default: 15).
+    def initialize(open_timeout: 5, read_timeout: 15)
+      @open_timeout = open_timeout
+      @read_timeout = read_timeout
+    end
+
     # Returns a listing of all valid Object IDs available to use based on the given parameters.
     # @param [Date, DateTime] metadataDate Returns objects with updated data after this date.
     # @param [Integer] departmentIds Returns objects in a specific department.
@@ -111,7 +118,7 @@ module MetMuseum
       return origin_response if limit.nil? || limit <= 0
 
       object_ids = origin_response["objectIDs"].take(limit)
-      object_ids.map { |id| MetMuseum::Collection.new.object(id) }
+      object_ids.map { |id| object(id) }
     end
 
     private
@@ -125,6 +132,8 @@ module MetMuseum
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.scheme == 'https'
+      http.open_timeout = @open_timeout
+      http.read_timeout = @read_timeout
 
       request = Net::HTTP::Get.new(uri.request_uri)
       http.request(request)
@@ -151,17 +160,6 @@ module MetMuseum
         raise MetMuseum.error_class(response_code), "Code: #{response_code}, response: #{response.body}"
       end
       JSON.parse(response.body)
-    end
-
-    def multi_option
-      case self
-      when String
-        return self
-      when Array
-        return join("|")
-      else
-        raise TypeError, "Write String or Array type"
-      end
     end
   end
 end

--- a/lib/met_museum/version.rb
+++ b/lib/met_museum/version.rb
@@ -1,3 +1,3 @@
 module MetMuseum
-  VERSION = "1.4.2".freeze
+  VERSION = "1.5.0".freeze
 end

--- a/spec/cassettes/MetMuseum_new_accepts_custom_open_read_timeouts_and_stays_functional.yml
+++ b/spec/cassettes/MetMuseum_new_accepts_custom_open_read_timeouts_and_stays_functional.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://collectionapi.metmuseum.org/public/collection/v1/departments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      X-Powered-By:
+      - ARR/3.0
+      - ASP.NET
+      Date:
+      - Wed, 24 Jun 2026 02:25:38 GMT
+      Set-Cookie:
+      - incap_ses_442_1662004=UNcjEKq38Gqz54Unu0wiBiJAO2oAAAAAUGtoyr+b1RzT539YUd7ZYw==;
+        path=/; Domain=.metmuseum.org
+      - visid_incap_1662004=b72VNClcQNKkQGT8tKefjiFAO2oAAAAAQUIPAAAAAADfLQzH9mHVOxBXFM8U2QNy;
+        expires=Wed, 23 Jun 2027 15:25:44 GMT; HttpOnly; path=/; Domain=.metmuseum.org
+      X-Cdn:
+      - Imperva
+      Transfer-Encoding:
+      - chunked
+      X-Iinfo:
+      - 54-95777274-95777329 NNYY CT(172 398 0) RT(1782267938676 187) q(0 0 0 13)
+        r(2 2) U12
+    body:
+      encoding: ASCII-8BIT
+      string: '{"departments":[{"departmentId":1,"displayName":"American Decorative
+        Arts"},{"departmentId":3,"displayName":"Ancient West Asian Art"},{"departmentId":4,"displayName":"Arms
+        and Armor"},{"departmentId":5,"displayName":"Arts of Africa, Oceania, and
+        the Americas"},{"departmentId":6,"displayName":"Asian Art"},{"departmentId":7,"displayName":"The
+        Cloisters"},{"departmentId":8,"displayName":"The Costume Institute"},{"departmentId":9,"displayName":"Drawings
+        and Prints"},{"departmentId":10,"displayName":"Egyptian Art"},{"departmentId":11,"displayName":"European
+        Paintings"},{"departmentId":12,"displayName":"European Sculpture and Decorative
+        Arts"},{"departmentId":13,"displayName":"Greek and Roman Art"},{"departmentId":14,"displayName":"Islamic
+        Art"},{"departmentId":15,"displayName":"The Robert Lehman Collection"},{"departmentId":16,"displayName":"The
+        Libraries"},{"departmentId":17,"displayName":"Medieval Art"},{"departmentId":18,"displayName":"Musical
+        Instruments"},{"departmentId":19,"displayName":"Photographs"},{"departmentId":21,"displayName":"Modern
+        Art"}]}
+
+        '
+  recorded_at: Wed, 24 Jun 2026 02:25:39 GMT
+recorded_with: VCR 6.4.0

--- a/spec/met_museum_spec.rb
+++ b/spec/met_museum_spec.rb
@@ -1,6 +1,13 @@
 RSpec.describe MetMuseum do
   let(:collection) { MetMuseum::Collection.new }
 
+  describe ".new" do
+    it "accepts custom open/read timeouts and stays functional" do
+      configured = MetMuseum::Collection.new(open_timeout: 3, read_timeout: 9)
+      expect(configured.department["departments"]).to be_an(Array)
+    end
+  end
+
   describe "#objects" do
     # Scope to a single small department so the recorded cassette stays small:
     # the unscoped /objects listing returns ~500k ids.


### PR DESCRIPTION
## 概要 (PR3/3: 内部品質 + 1.5.0)

近代化の最終弾。公開 API は壊さず（既存メソッドのシグネチャ・戻り値は不変）、internal 品質を上げて additive なタイムアウトオプションを足し、節目として **1.5.0** にバンプする。

## 変更
- **タイムアウト設定可能化（additive）**: `MetMuseum::Collection.new(open_timeout:, read_timeout:)`（既定 5s / 15s）を追加し、`Net::HTTP` に適用。無引数の `Collection.new` は従来どおり動くので後方互換。
- **search の N+1 解消**: `search(limit:)` が件数分 `MetMuseum::Collection.new` を生成していたのを `object(id)`（self 再利用）に変更。設定したタイムアウトも引き継がれる。
- **死にコード削除**: 誰からも呼ばれていなかった private `multi_option` を削除。
- `version.rb` → `1.5.0`、`CHANGELOG.md` 新規、README にタイムアウト例を追記。

## テスト
- 新規: 「カスタムタイムアウトで構築しても正常に動く」例を追加（VCR カセット同梱）
- 既存 21 例は VCR で全緑、合計 **22 examples, 0 failures**（オフライン 0.05s）
- `gem build` で `Version: 1.5.0` を確認

## リリースについて ⚠️
- このPRはコードのみ。**RubyGems への `gem push`（1.5.0 公開）は未実施**。マージ後、あなたの明示的な合図を受けてから別途実行する想定（外部公開・不可逆のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)